### PR TITLE
Add Jest test for audio button

### DIFF
--- a/js/script.test.js
+++ b/js/script.test.js
@@ -1,0 +1,36 @@
+const path = require('path');
+const { JSDOM } = require('jsdom');
+
+describe('audio button toggle', () => {
+  let document;
+  let button;
+
+  beforeAll(async () => {
+    const dom = await JSDOM.fromFile(path.join(__dirname, '../index.html'), {
+      runScripts: 'dangerously',
+      resources: 'usable',
+    });
+
+    await new Promise(resolve => {
+      dom.window.document.addEventListener('DOMContentLoaded', resolve);
+    });
+
+    document = dom.window.document;
+    button = document.getElementById('audioButton');
+  });
+
+  test('toggles classes on click', () => {
+    expect(button.classList.contains('muted')).toBe(true);
+    expect(button.classList.contains('unmuted')).toBe(false);
+
+    button.click();
+
+    expect(button.classList.contains('unmuted')).toBe(true);
+    expect(button.classList.contains('muted')).toBe(false);
+
+    button.click();
+
+    expect(button.classList.contains('muted')).toBe(true);
+    expect(button.classList.contains('unmuted')).toBe(false);
+  });
+});

--- a/package.json
+++ b/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "abadfederico.github.io",
+  "version": "1.0.0",
+  "scripts": {
+    "test": "jest"
+  },
+  "devDependencies": {
+    "jest": "^29.6.1",
+    "jsdom": "^22.1.0"
+  }
+}


### PR DESCRIPTION
## Summary
- add package.json with Jest setup
- test toggle of audioButton class using jsdom

## Testing
- `npm install` *(fails: 403 Forbidden)*
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68450ecb768c8330939372c4fc905928